### PR TITLE
Add remote MCP client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # multiagent
 
 This project demonstrates a minimal multi-agent system using `fastmcp` for tool servers,
-`python_a2a` for agent communication, and `langgraph` for orchestration.
+`python_a2a` for agent communication, and `langgraph` for orchestration. Real MCP servers
+are accessed through `MultiServerMCPClient` from `langchain-mcp-adapters`. Example
+connections include the community memory server and the Brave Search MCP server (requiring
+the `BRAVE_API_KEY` environment variable).
 
 Three agents are provided:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "python-a2a",
     "requests",
     "langgraph",
-    "pytest"
+    "pytest",
+    "langchain-mcp-adapters"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -26,7 +26,7 @@ def wait(url: str, attempts: int = 30):
 
 
 def start(cmd):
-    env = dict(**os.environ, PYTHONPATH=".")
+    env = dict(**os.environ, PYTHONPATH=".", DISABLE_REMOTE_MCP="1")
     # Use the same Python interpreter that's running the tests
     python_executable = sys.executable
     # Capture stdout and stderr but don't redirect to PIPE to avoid blocking


### PR DESCRIPTION
## Summary
- add langchain-mcp-adapters dependency
- wire up MultiServerMCPClient in `ToolAgent` with optional disabling via env variable
- record interactions to the community memory server
- use Brave Search MCP server when available
- store search results in memory
- update tests to disable remote MCP usage
- document new servers in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b82270948330b6c01bf5b6fa22a5