### PR TITLE
Add streaming web UI and integrate extra MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # multiagent
 
-This project demonstrates a minimal multi-agent system using `fastmcp` for tool servers,
-`python_a2a` for agent communication, and `langgraph` for orchestration. Real MCP servers
-are accessed through `MultiServerMCPClient` from `langchain-mcp-adapters`. Example
-connections include the community memory server and the Brave Search MCP server (requiring
-the `BRAVE_API_KEY` environment variable).
+This project demonstrates a minimal multi-agent system using **FastMCP** for tool servers,
+**python-a2a** for agent communication, and **langgraph** for orchestration. Agents rely on
+OpenAI's `gpt-4o` model for reasoning. Real MCP servers are accessed through `MultiServerMCPClient`
+from `langchain-mcp-adapters`. Example connections include the community memory server, the
+Brave Search MCP server (requiring the `BRAVE_API_KEY` environment variable) and additional
+public servers for searching everything and manipulating Excel files.
 
 Three agents are provided:
 
@@ -15,3 +16,9 @@ Three agents are provided:
 Agents register with a discovery registry and communicate via the A2A protocol.
 Tests launch all agents and verify an end‑to‑end workflow where the Search Agent
 uses the other agents to answer a task.
+
+## Web interface
+
+A small Flask app (`gui.py`) provides a simple chat UI. Run it alongside the agents
+and open `http://localhost:8000` to send messages to any agent. Responses stream
+live so you can watch each agent think and interact with MCP tools.

--- a/agents/base.py
+++ b/agents/base.py
@@ -39,6 +39,14 @@ class ToolAgent(A2AServer):
                         "env": {"BRAVE_API_KEY": os.environ.get("BRAVE_API_KEY", "")},
                         "transport": "stdio",
                     },
+                    "everything-search": {
+                        "url": "https://mcpservers.org/servers/mamertofabian/mcp-everything-search/mcp",
+                        "transport": "streamable_http",
+                    },
+                    "excel": {
+                        "url": "https://mcpservers.org/servers/haris-musa/excel-mcp-server/mcp",
+                        "transport": "streamable_http",
+                    },
                 }
             )
         else:

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,71 @@
+from flask import Flask, render_template_string, request, Response, stream_with_context
+import asyncio
+from python_a2a.client.streaming import StreamingClient
+from python_a2a.models import Message, TextContent, MessageRole
+
+AGENT_PORTS = {
+    "Math Agent": 9011,
+    "Quote Agent": 9012,
+    "Search Agent": 9013,
+}
+
+HTML = """<!doctype html>
+<title>Multi-Agent Chat</title>
+<select id=agent>
+{% for name in agents %}<option value="{{name}}">{{name}}</option>{% endfor %}
+</select>
+<input id=msg size=60 placeholder="Enter message"/>
+<button onclick="send()">Send</button>
+<pre id=log></pre>
+<script>
+function send(){
+  const agent=document.getElementById('agent').value;
+  const msg=document.getElementById('msg').value;
+  const log=document.getElementById('log');
+  log.textContent='';
+  const es=new EventSource(`/chat?agent=${encodeURIComponent(agent)}&message=${encodeURIComponent(msg)}`);
+  es.onmessage=e=>{ log.textContent += e.data + "\n"; };
+}
+</script>
+"""
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template_string(HTML, agents=AGENT_PORTS.keys())
+
+@app.route('/chat')
+def chat():
+    agent = request.args.get('agent')
+    text = request.args.get('message', '')
+    if agent not in AGENT_PORTS:
+        return 'unknown agent', 400
+    url = f"http://localhost:{AGENT_PORTS[agent]}/a2a"
+
+    async def astream():
+        client = StreamingClient(url)
+        message = Message(content=TextContent(text=text), role=MessageRole.USER)
+        async for chunk in client.stream_response(message):
+            if isinstance(chunk, dict):
+                yield chunk.get('content', str(chunk))
+            else:
+                yield chunk
+
+    def generate():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        agen = astream()
+        try:
+            while True:
+                chunk = loop.run_until_complete(agen.__anext__())
+                yield f"data: {chunk}\n\n"
+        except StopAsyncIteration:
+            pass
+        finally:
+            loop.close()
+
+    return Response(stream_with_context(generate()), mimetype='text/event-stream')
+
+if __name__ == '__main__':
+    app.run(port=8000, debug=True)


### PR DESCRIPTION
## Summary
- add a Flask based GUI for chatting with the running agents
- wire additional public MCP servers in `ToolAgent`
- document the GUI and GPT‑4o usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868bd38bf408330bbc7469b7352e6f7