### PR TITLE
Add LangGraph LLM agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Three agents are provided:
 - **Math Agent** – exposes a calculator via an MCP server.
 - **Quote Agent** – fetches random quotes.
 - **Search Agent** – searches the internet and coordinates the other agents using LangGraph.
+- **LangGraph LLM Agent** – example agent that wires an OpenAI LLM into the ToolAgent
+  using LangGraph's `create_react_agent`. It can call both local MCP tools and
+  any remote tools discovered via `MultiServerMCPClient`.
 
 Agents register with a discovery registry and communicate via the A2A protocol.
 Tests launch all agents and verify an end‑to‑end workflow where the Search Agent

--- a/agents/llm_agent.py
+++ b/agents/llm_agent.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import os
+import anyio
+import logging
+from agents.base import ToolAgent
+from langchain_openai import ChatOpenAI
+from langchain.agents import AgentExecutor
+from langgraph.prebuilt import create_react_agent
+from python_a2a.models import Message, TextContent, MessageRole
+
+logger = logging.getLogger("llm_agent")
+
+class LangGraphToolAgent(ToolAgent):
+    """ToolAgent that uses a LangGraph ReAct agent backed by an LLM."""
+
+    def _make_llm(self) -> ChatOpenAI:
+        model = os.environ.get("OPENAI_MODEL", "gpt-4o")
+        api_key = os.environ.get("OPENAI_API_KEY")
+        return ChatOpenAI(model=model, api_key=api_key, streaming=True, temperature=0.2)
+
+    def _gather_local_tools(self):
+        from langchain_mcp_adapters.tools import load_mcp_tools
+        from langchain_mcp_adapters.sessions import StreamableHttpConnection
+        connection: StreamableHttpConnection = {
+            "transport": "streamable_http",
+            "url": f"http://localhost:{self.mcp_port}/mcp",
+        }
+        return anyio.run(load_mcp_tools(None, connection=connection))
+
+    async def _gather_remote_tools(self):
+        if not self.remote_client:
+            return []
+        tools = []
+        for srv in await self.remote_client.list_servers():
+            srv_tools = await self.remote_client.get_tools(server_name=srv)
+            tools.extend(srv_tools)
+        return tools
+
+    def _init_agent(self):
+        llm = self._make_llm()
+        tools = self._gather_local_tools()
+        if self.remote_client:
+            tools += anyio.run(self._gather_remote_tools())
+        react_agent = create_react_agent(llm=llm, tools=tools)
+        self.executor = AgentExecutor(agent=react_agent, tools=tools, verbose=True, max_iterations=6)
+
+    def start_mcp(self):
+        super().start_mcp()
+        self._init_agent()
+
+    def handle_message(self, message: Message) -> Message:
+        if not hasattr(self, "executor"):
+            self._init_agent()
+        result = anyio.run(lambda: self.executor.invoke({"input": message.content.text}))
+        return Message(
+            role=MessageRole.AGENT,
+            content=TextContent(text=result["output"]),
+            parent_message_id=message.message_id,
+            conversation_id=message.conversation_id,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -905,6 +905,20 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-mcp-adapters"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "mcp" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/f2/f61eef5dc4b7e2bbb65ea904d59b96bd36c7017265c8e4a99c23688771cd/langchain_mcp_adapters-0.1.8.tar.gz", hash = "sha256:5fc6a596b73be96198135a11707102e3a7e9470b4d149bbbb1c9f9d902e0fa42", size = 20750, upload-time = "2025-06-30T19:28:46.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/28/86e7abd8ca1ba9057556d1b3c562f61fa068eb59ca7f74aea0dbc1c58115/langchain_mcp_adapters-0.1.8-py3-none-any.whl", hash = "sha256:037323b772f3214986b127fe89d2e7e721ca5e852a618cdbbf00cc955154cc90", size = 13795, upload-time = "2025-06-30T19:28:44.75Z" },
+]
+
+[[package]]
 name = "langchain-text-splitters"
 version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1097,6 +1111,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anyio" },
     { name = "fastmcp" },
+    { name = "langchain-mcp-adapters" },
     { name = "langgraph" },
     { name = "pytest" },
     { name = "python-a2a" },
@@ -1112,6 +1127,7 @@ dev = [
 requires-dist = [
     { name = "anyio" },
     { name = "fastmcp" },
+    { name = "langchain-mcp-adapters" },
     { name = "langgraph" },
     { name = "pytest" },
     { name = "pytest", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary
- provide an example agent that uses `create_react_agent` to wire an OpenAI LLM
- document new LangGraph LLM agent in README
- update lockfile

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c6a62ffc8330ae70fbfd1a35a93b