### PR TITLE
Fix agent discovery initialization

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -146,7 +146,8 @@ class ToolAgent(A2AServer):
         """Discover and cache other agents at startup with retries."""
         try:
             from python_a2a.discovery.client import DiscoveryClient
-            discovery_client = DiscoveryClient(self._registry_url)
+            discovery_client = DiscoveryClient(self.agent_card)
+            discovery_client.add_registry(self._registry_url)
             
             # Wait for registry and other agents to start with retries
             max_attempts = 8  # Increased from 5 to 8
@@ -281,7 +282,8 @@ class ToolAgent(A2AServer):
         """Perform a discovery update without the startup retries."""
         try:
             from python_a2a.discovery.client import DiscoveryClient
-            discovery_client = DiscoveryClient(self._registry_url)
+            discovery_client = DiscoveryClient(self.agent_card)
+            discovery_client.add_registry(self._registry_url)
             
             agents = discovery_client.discover()
             other_agents = [agent for agent in agents if agent.name != self.name]

--- a/issue_registry_discovery.md
+++ b/issue_registry_discovery.md
@@ -1,0 +1,7 @@
+# Issue: Agent Discovery Broken
+
+Agents were unable to discover peers because `DiscoveryClient` was initialized with the registry URL instead of an `AgentCard`. This left the client's `registry_urls` empty, causing `discover()` to return no agents.
+
+## Fix
+
+Create `DiscoveryClient` with the agent's own card and explicitly call `add_registry()` with the registry URL before calling `discover()`.

--- a/test_periodic_discovery.py
+++ b/test_periodic_discovery.py
@@ -15,8 +15,9 @@ def test_periodic_discovery():
     print("🧪 Testing Periodic Agent Discovery...")
     print("=" * 60)
     
-    # Change to project directory
-    os.chdir(r'c:\Users\randy\Git\multiagent')
+    # Change to project directory (current repo root)
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(repo_root)
     
     processes = []
     


### PR DESCRIPTION
## Summary
- create new DiscoveryClient with agent card and registry URL
- adjust periodic discovery to add registry
- fix periodic discovery test path
- document issue discovered

## Testing
- `pytest -q` *(fails: tests/test_e2e.py::test_individual_agents, tests/test_e2e.py::test_workflow)*

------
https://chatgpt.com/codex/tasks/task_e_6886a7be7a0c8330a46ad95238395d3a